### PR TITLE
Fix cypress.config.ts problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,17 +91,17 @@ module.exports = defineConfig({
 npx cypress run
 ```
 
-2. If there are failed tests, run the following command from the **directory of the project's `cypress.config`**:
+2. If there are failed tests, run the following command from the **failedTestDirectory of the project**:
 
 ```bash
-npx cypress-last-failed run
+npx cypress-plugin-last-failed run
 ```
 
 You can also include more cli arguments similar to `cypress run`, as the command harnesses the power of [Cypress module API](https://docs.cypress.io/guides/guides/module-api):
 
 ```bash
 # Example
-npx cypress-last-failed run --e2e --browser chrome
+npx cypress-plugin-last-failed run --e2e --browser chrome
 ```
 
 ### Optional custom `failedTestDirectory`
@@ -141,7 +141,7 @@ For convenience, you may desire to house the `npx` command within an npm script 
 
 ```json
   "scripts": {
-    "last-failed": "npx cypress-run-last-failed run --e2e --browser electron"
+    "last-failed": "cd ${failedTestDirectory} && npx cypress-plugin-last-failed run --e2e --browser electron"
   }
 ```
 

--- a/runFailed.js
+++ b/runFailed.js
@@ -4,7 +4,6 @@ const cypress = require('cypress');
 const fs = require('fs');
 const path = require('path');
 const appDir = process.env.INIT_CWD ? process.env.INIT_CWD : path.resolve('.');
-const cypressConfig = require(`${appDir}/cypress.config`);
 
 async function runLastFailed() {
   const noFailedTestsMessage =
@@ -12,10 +11,7 @@ async function runLastFailed() {
 
   // Use the cypress environment variable failedTestDirectory for where to store failed tests
   // If not set then use the directory of the project's cypress.config where the test-results defaults to
-  const failedTestFilePath =
-    cypressConfig.env?.failedTestDirectory === undefined
-      ? `${appDir}/test-results/last-run.txt`
-      : `${cypressConfig.env.failedTestDirectory}/test-results/last-run.txt`;
+  const failedTestFilePath = `${appDir}/test-results/last-run.txt`;
 
   if (fs.existsSync(failedTestFilePath)) {
     // Retrieve the failedTests from the file


### PR DESCRIPTION
We've encountered different problems using the plugin in our Cypress project using TypeScript, first of all, `runFailed.js` didn't find our Cypress configuration and when we fixed that, the "Cannot use import statement outside a module" error appeared. The problem is that we need the config before initializing Cypress, so we solved that by removing that line. Now the plugin' script is forced to be in the correct directory when executing.