### PR TITLE
fix: Refactor `grepFailed`/toggle use in `open` mode to account for passing retries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Thanks for being willing to contribute!
 Please make sure to run the node script before you commit your changes:
 
 ```bash
-npx cypress-last-failed run
+npx cypress-plugin-last-failed run
 ```
 
 For changes related to the `cypress open` toggle, you can run `npx cypress open` to test functionality in the Cypress Test Runner UI. Make sure to include any test changes (if they exist) in your commit.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A companion Cypress plugin for <code>cy-grep</code> that re-runs the last failed
   - [Setting up a `npm` script](#-setting-up-a-npm-script)
 - [Open mode](#-open-mode)
   - [Recommended open mode env variables](#recommended-open-mode-env-variables)
+  - [Use Required Test Tags Instead Of Skipping Tests](#use-required-test-tags-instead-of-skipping-tests)
 - [CI support](#continuous-integration-support)
 - [Typescript support](#typescript-support)
 - [Contributions](#contributions)
@@ -150,6 +151,29 @@ Toggling the filter will run any previously failed tests on the particular spec 
 
 > [!NOTE]
 > More information on `grepOmitFiltered` and `grepFilterSpecs` can be read within the [README for `@bahmutov/cy-grep`](https://github.com/bahmutov/cy-grep?tab=readme-ov-file#pre-filter-specs-grepfilterspecs).
+
+### Use Required Test Tags Instead Of Skipping Tests
+
+> [!NOTE]
+> Read more about this topic within a blog post [Use Required Test Tags Instead Of Skipping Tests](https://glebbahmutov.com/blog/required-tags-instead-of-skipped-tests/) and within the [README for `@bahmutov/cy-grep`](https://github.com/bahmutov/cy-grep#required-tags).
+
+Normally, any Cypress test or suite of tests marked with a `.skip` will be shown when running tests or within the Cypress test runner UI.
+
+Since this plugin uses `@bahmutov/cy-grep` plugin, we can instead designate skipped tests using a **required tag**:
+
+```js
+it('deletes an item', { requiredTags: '@skip' }, () => {
+  expect(1).to.equal(2);
+});
+```
+
+Now running or opening Cypress in interactive mode, **you will not see any tests with `requiredTags` including `@skip`** (unless setting environment variable `grepTags=@skip`).
+
+To run just those tests with the required tag `@skip` in interactive mode:
+
+```bash
+npx cypress open --env grepTags=@skip
+```
 
 ---
 

--- a/cypress/e2e/tests.cy.js
+++ b/cypress/e2e/tests.cy.js
@@ -6,9 +6,11 @@ describe('Should run expected tests', () => {
       expect(true).to.eq(false);
     }
   });
+
   it('should not run', () => {
     expect(true).to.eq(true);
   });
+
   it('needs to run', () => {
     if (Cypress.env('shouldPass')) {
       expect(1).to.eq(1);
@@ -16,11 +18,24 @@ describe('Should run expected tests', () => {
       expect(1).to.eq(2);
     }
   });
+
   it('will be included in failed tests', () => {
     if (Cypress.env('shouldPass')) {
       expect(10).to.eq(10);
     } else {
       expect(10).to.eq(2);
     }
+  });
+
+  it('retry', { requiredTags: '@skip', retries: 1 }, () => {
+    if (Cypress.currentRetry === 0) {
+      expect(10).to.eq(2);
+    } else {
+      expect(10).to.eq(10);
+    }
+  });
+
+  it('skipped', { requiredTags: '@skip' }, () => {
+    expect(10).to.eq(10);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-plugin-last-failed",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "bin": {
         "cypress-plugin-last-failed": "runFailed.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Cypress plugin to rerun last failed tests in cypress run and open mode",
   "main": "./src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,37 @@ const collectFailingTests = (on, config) => {
 };
 
 /**
+ * Find and grep all the failed test titles designated within the Cypress Test Runner UI.
+ *
+ * Any retried tests that failed but ultimately passed will not be included.
+ *
+ * See README for recommendation on handling skipped tests ordinarily seen within the Cypress Test Runner UI.
+ */
+
+const grepFailed = () => {
+  // @ts-ignore
+  const failedTestTitles = [];
+
+  const failedTests = window.top?.document.querySelectorAll(
+    '.test.runnable.runnable-failed'
+  );
+
+  [...failedTests].forEach((test) => {
+    failedTestTitles.push(test.innerText.split('\n')[0]);
+  });
+
+  if (!failedTestTitles.length) {
+    console.log('No failed tests found');
+  } else {
+    console.log('running only the failed tests');
+    const grepTitles = failedTestTitles.join('; ');
+    console.log(grepTitles);
+    // @ts-ignore
+    Cypress.grep(grepTitles);
+  }
+};
+
+/**
  * Toggle for use within a spec file during `cypress open`
  */
 
@@ -176,7 +207,8 @@ const failedTestToggle = () => {
         stopBtn.click();
       }
       // when checked, grep only failed tests in spec
-      Cypress.grepFailed();
+      grepFailed();
+
       runFailedLabelElement.innerHTML = turnOnRunFailedIcon;
       runFailedTooltipElement.innerHTML = turnOnRunFailedDescription;
     } else {


### PR DESCRIPTION
Relates to: #3 

- Refactor the `grepFailed` function/toggle use in `cypress open` mode to not run passing retried tests
- Update README documentation on handling skipped tests using required tags from `cy-grep` package
- Updates some tests within repo to use required tags for demonstration