### PR TITLE
feat: Reformat last-run failed test file as json for easier readability

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Output the file contents 📝
         if: always()
         run: |
-          cat ./test-results/last-run.txt
+          cat ./test-results/last-run.json
       - name: Custom tests 🧪
         if: always()
         uses: cypress-io/github-action@v6

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ jobs:
       - name: Output the file contents 📝
         if: always()
         run: |
-          cat ./test-results/last-run.txt
+          cat ./test-results/last-run.json
       - name: Custom tests 🧪
         if: always()
         uses: cypress-io/github-action@v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-plugin-last-failed",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "bin": {
         "cypress-plugin-last-failed": "runFailed.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Cypress plugin to rerun last failed tests in cypress run and open mode",
   "main": "./src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -28,8 +28,8 @@ const collectFailingTests = (on, config) => {
       for (i in tests) {
         let report = {
           spec: spec,
-          parent: tests[i][0],
-          test: tests[i][1],
+          parent: [...tests[i].slice(0, -1)],
+          test: tests[i].pop(),
         };
         // Only store non empty test titles
         if (tests != '') {

--- a/src/index.js
+++ b/src/index.js
@@ -21,17 +21,22 @@ const collectFailingTests = (on, config) => {
     for (i in results.runs) {
       const tests = results.runs[i].tests
         .filter((test) => test.state === 'failed')
-        .map((test) => test.title[test.title.length - 1]);
+        .map((test) => test.title);
 
-      // Only store non empty test titles
-      if (tests != '') {
-        failedTests.push(tests);
+      const spec = results.runs[i].spec.relative;
+
+      for (i in tests) {
+        let report = {
+          spec: spec,
+          parent: tests[i][0],
+          test: tests[i][1],
+        };
+        // Only store non empty test titles
+        if (tests != '') {
+          failedTests.push(report);
+        }
       }
     }
-
-    const stringedTests = failedTests.toString();
-    // Prepare a string that can be read from cy-grep
-    const greppedTestFormat = stringedTests.replaceAll(',', '; ');
 
     // Use the cypress.config directory for path for storing test-results
     const failedTestFileDirectory = `${path.dirname(
@@ -44,9 +49,9 @@ const collectFailingTests = (on, config) => {
     });
     const lastRunReportFile = path.join(
       `${failedTestFileDirectory}`,
-      'last-run.txt'
+      'last-run.json'
     );
-    await fs.promises.writeFile(lastRunReportFile, greppedTestFormat);
+    await fs.promises.writeFile(lastRunReportFile, JSON.stringify(failedTests));
   });
 
   return collectFailingTests;


### PR DESCRIPTION
# Overview

Relates to: [Reformat last-run failed test file as json for easier readability #7](https://github.com/dennisbergevin/cypress-plugin-last-failed/issues/7)

Reformats the `test-results/last-run` file to a `.json` to improve readability of the failed test file, showing spec, parent (suite) name, and test name.

Example `test-results/last-run.json` file after a `cypress run` showing failed tests (spec, parent(s), test):

```json
[
  {
    "spec": "cypress/e2e/spec.cy.ts",
    "parent": ["template spec"],
    "test": "fails"
  },
  {
    "spec": "cypress/e2e/1-getting-started/todo.cy.js",
    "parent": ["example to-do app"],
    "test": "can check off an item as completed"
  },
  {
    "spec": "cypress/e2e/2-advanced-examples/assertions.cy.js",
    "parent": ["Assertions", "Explicit Assertions"],
    "test": "pass your own callback function to should()"
  }
]
```

Example CI run: https://github.com/dennisbergevin/cypress-plugin-last-failed/actions/runs/9734252741/job/26862054893

## Parent suite title(s) inclusive

In addition to the specific test title, the `grep` will also use the parent suite title(s) preceding the test title to guard against the scenario when the same test title could be in a different spec file.

Example: 

```
cy-grep: tests with "Should run expected tests should run; Should run expected tests needs to run; Should run expected tests will be included in failed tests" in their names
```