### PR TITLE
feat: custom last failed results path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,16 @@ A companion Cypress plugin for <code>cy-grep</code> that re-runs the last failed
 
 #### Table of Contents
 
-- [Installation](#-installation)
-- [Run mode](#-run-mode)
+- [Features](#features)
+    - [Table of Contents](#table-of-contents)
+- [📦 Installation](#-installation)
+- [👟 Run mode](#-run-mode)
   - [Add rule to gitignore](#add-rule-to-gitignore)
-  - [Setting up a `npm` script](#-setting-up-a-npm-script)
-- [Open mode](#-open-mode)
+  - [📃 Setting up a `npm` script](#-setting-up-a-npm-script)
+- [⌛ Open mode](#-open-mode)
   - [Recommended open mode env variables](#recommended-open-mode-env-variables)
   - [Use Required Test Tags Instead Of Skipping Tests](#use-required-test-tags-instead-of-skipping-tests)
-- [CI support](#continuous-integration-support)
+- [Continuous integration support](#continuous-integration-support)
 - [Typescript support](#typescript-support)
 - [Contributions](#contributions)
 
@@ -43,9 +45,9 @@ npm install --save-dev cypress-plugin-last-failed
 2. In `cypress/support/e2e.js` (For E2E tests) and/or `cypress/support/component.js` (For Component tests),
 
 ```js
-import { failedTestToggle } from 'cypress-plugin-last-failed';
+import { failedTestToggle } from "cypress-plugin-last-failed";
 
-const registerCypressGrep = require('@bahmutov/cy-grep');
+const registerCypressGrep = require("@bahmutov/cy-grep");
 registerCypressGrep();
 
 failedTestToggle();
@@ -54,8 +56,8 @@ failedTestToggle();
 3. In `cypress.config`, include the following within `setupNodeEvents` for `e2e` and/or `component` testing:
 
 ```js
-const { defineConfig } = require('cypress');
-const { collectFailingTests } = require('cypress-plugin-last-failed');
+const { defineConfig } = require("cypress");
+const { collectFailingTests } = require("cypress-plugin-last-failed");
 
 module.exports = defineConfig({
   screenshotOnRunFailure: false,
@@ -67,7 +69,7 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       collectFailingTests(on, config);
 
-      require('@bahmutov/cy-grep/src/plugin')(config);
+      require("@bahmutov/cy-grep/src/plugin")(config);
       return config;
     },
   },
@@ -75,7 +77,7 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       collectFailingTests(on, config);
 
-      require('@bahmutov/cy-grep/src/plugin')(config);
+      require("@bahmutov/cy-grep/src/plugin")(config);
       return config;
     },
   },
@@ -106,7 +108,14 @@ You can also include more cli arguments similar to `cypress run`, as the command
 npx cypress-plugin-last-failed run --e2e --browser chrome
 ```
 
-There will be a folder called `test-results` created in the directory of the `cypress.config`.
+There will be a folder called test-results created in the directory of the cypress.config. If you would like to specify a different folder for test results, use the LAST_FAILED_RESULTS_PATH environment variable:
+
+```bash
+# Example
+LAST_FAILED_RESULTS_PATH=cypress/custom-test-results npx cypress-plugin-last-failed run
+```
+
+This environment variable will direct the plugin to store or retrieve the last run's failed test results from the specified folder.
 
 ### Add rule to gitignore
 
@@ -162,7 +171,7 @@ Normally, any Cypress test or suite of tests marked with a `.skip` will be shown
 Since this plugin uses `@bahmutov/cy-grep` plugin, we can instead designate skipped tests using a **required tag**:
 
 ```js
-it('deletes an item', { requiredTags: '@skip' }, () => {
+it("deletes an item", { requiredTags: "@skip" }, () => {
   expect(1).to.equal(2);
 });
 ```
@@ -186,7 +195,7 @@ name: test-last-failed-node-script
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   pull_request:
   workflow_dispatch:
 

--- a/cypress/config/cypress.config.js
+++ b/cypress/config/cypress.config.js
@@ -1,0 +1,26 @@
+const { defineConfig } = require("cypress");
+const { collectFailingTests } = require("../../src/index");
+
+module.exports = defineConfig({
+  env: {
+    grepOmitFiltered: true,
+    grepFilterSpecs: true,
+  },
+  screenshotOnRunFailure: false,
+  e2e: {
+    setupNodeEvents(on, config) {
+      require("@bahmutov/cy-grep/src/plugin")(config);
+      collectFailingTests(on, config);
+
+      return config;
+    },
+  },
+  component: {
+    setupNodeEvents(on, config) {
+      require("@bahmutov/cy-grep/src/plugin")(config);
+      collectFailingTests(on, config);
+
+      return config;
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.0",
   "description": "Cypress plugin to rerun last failed tests in cypress run and open mode",
   "main": "./src/index.js",
+  "types": "./src/index.d.ts",
   "scripts": {
     "last-failed": "npx cypress-plugin-last-failed run --e2e --browser electron"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Cypress plugin to rerun last failed tests in cypress run and open mode",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/runFailed.js
+++ b/runFailed.js
@@ -1,20 +1,27 @@
 #!/usr/bin/env node
 
-const cypress = require('cypress');
-const fs = require('fs');
-const path = require('path');
-const appDir = process.env.INIT_CWD ? process.env.INIT_CWD : path.resolve('.');
+const cypress = require("cypress");
+const fs = require("fs");
+const path = require("path");
+const appDir = process.env.INIT_CWD ? process.env.INIT_CWD : path.resolve(".");
 
 async function runLastFailed() {
   const noFailedTestsMessage = `No previous failed tests detected
 Ensure you are in the directory of your cypress config
 Try running tests again with cypress run`;
 
-  const failedTestFilePath = `${appDir}/test-results/last-run.json`;
+  const failedTestFilePath = process.env.LAST_FAILED_RESULTS_PATH
+    ? path.join(
+        appDir,
+        process.env.LAST_FAILED_RESULTS_PATH,
+        "test-results",
+        "last-run.json"
+      )
+    : path.join(appDir, "test-results", "last-run.json");
 
   if (fs.existsSync(failedTestFilePath)) {
     // Retrieve the failedTests from the file
-    const failedTests = await fs.promises.readFile(failedTestFilePath, 'utf8');
+    const failedTests = await fs.promises.readFile(failedTestFilePath, "utf8");
 
     // Retrieve the parent suite and tests in the results from test-results/last-run
     const parentAndTest = JSON.parse(failedTests).map(({ parent, test }) => ({
@@ -24,13 +31,13 @@ Try running tests again with cypress run`;
     // Combine parent suite and test together
     const resultSet = new Set(
       Object.values(parentAndTest).flatMap(
-        (parent) => parent.parent + ',' + parent.test + ';'
+        (parent) => parent.parent + "," + parent.test + ";"
       )
     );
     // Format string for use in grep functionality
     const stringedTests = Array.from(resultSet)
       .toString()
-      .replaceAll(',', ' ')
+      .replaceAll(",", " ")
       .slice(0, -1);
 
     if (stringedTests.length > 0) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,23 @@
+// index.d.ts
+declare module "cypress-plugin-last-failed" {
+  /**
+   * Collects failed tests from the most recent Cypress test run.
+   *
+   * After each run, a file will store failed test titles within a test-results directory.
+   *
+   * @param {Function} on - Cypress event registration function.
+   * @param {object} config - Cypress config object.
+   * @returns {void}
+   */
+  export function collectFailingTests(
+    on: (event: string, callback: Function) => void,
+    config: { env: { TEST_RESULTS_PATH?: string }; configFile: string }
+  ): void;
+
+  /**
+   * Toggles the display of failed tests in the Cypress UI.
+   *
+   * @returns {void}
+   */
+  export function failedTestToggle(): void;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,60 +1,68 @@
-const fs = require('fs');
-const path = require('path');
-const failedTestToggle = require('./toggle');
+const fs = require("fs");
+const path = require("path");
+const failedTestToggle = require("./toggle");
+
 /**
  * Collects failed tests from the most recent Cypress test run
  *
  * After each run, a file will store failed test titles within a test-results directory
  *
- * The test-results directory will be stored in cypress.config directory
+ * The test-results directory will be stored in the cypress.config directory
  *
  * Subsequent test runs containing failed tests will overwrite this file
  * @param {*} on
  * @param {*} config
  * @returns
  */
-
 const collectFailingTests = (on, config) => {
-  on('after:run', async (results) => {
+  on("after:run", async (results) => {
     let failedTests = [];
-    // Grab every failed test's title
-    for (i in results.runs) {
-      const tests = results.runs[i].tests
-        .filter((test) => test.state === 'failed')
-        .map((test) => test.title);
 
-      const spec = results.runs[i].spec.relative;
+    for (const run of results.runs) {
+      if (run.tests && run.spec) {
+        const tests = run.tests
+          .filter((test) => test.state === "failed")
+          .map((test) => test.title);
 
-      for (i in tests) {
-        let report = {
-          spec: spec,
-          parent: [...tests[i].slice(0, -1)],
-          test: tests[i].pop(),
-        };
-        // Only store non empty test titles
-        if (tests != '') {
-          failedTests.push(report);
-        }
+        const spec = run.spec.relative;
+
+        failedTests = failedTests.concat(generateReports(tests, spec));
       }
     }
 
-    // Use the cypress.config directory for path for storing test-results
-    const failedTestFileDirectory = `${path.dirname(
-      config.configFile
-    )}/test-results/`;
+    // Use process.env.LAST_FAILED_RESULTS_PATH or fallback to the default path
+    const failedTestFilePath = process.env.LAST_FAILED_RESULTS_PATH
+      ? path.join(
+          process.env.INIT_CWD,
+          process.env.LAST_FAILED_RESULTS_PATH,
+          "test-results"
+        )
+      : `${path.dirname(config.configFile)}/test-results/`;
 
     // Create the directory and last-run file where failed tests will be written to
-    await fs.promises.mkdir(`${failedTestFileDirectory}`, {
-      recursive: true,
-    });
-    const lastRunReportFile = path.join(
-      `${failedTestFileDirectory}`,
-      'last-run.json'
-    );
+    await fs.promises.mkdir(failedTestFilePath, { recursive: true });
+    const lastRunReportFile = path.join(failedTestFilePath, "last-run.json");
     await fs.promises.writeFile(lastRunReportFile, JSON.stringify(failedTests));
   });
 
   return collectFailingTests;
+};
+
+const generateReports = (tests, spec) => {
+  const reports = [];
+  for (const test of tests) {
+    const testCopy = [...test]; // Create a copy of the array to avoid mutation
+    const testTitle = testCopy.pop(); // Extract the test title
+    if (testTitle) {
+      const report = {
+        spec: spec,
+        parent: testCopy, // Parent titles
+        test: testTitle, // The actual test title
+      };
+      reports.push(report);
+    }
+  }
+  return reports;
 };
 
 module.exports = { collectFailingTests, failedTestToggle };


### PR DESCRIPTION
We may have repositories where the cypress.config file is not at the repo root, expected by the plugin.

The feature adds the ability to run the tests with `LAST_FAILED_RESULTS_PATH` env var, with which we can specify the location of `test-results` folder.