### PR TITLE
fix: Adding logic around burning tests via cy-grep

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  default-test-results:
+  default-dir-test-results:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout 📦
@@ -26,7 +26,30 @@ jobs:
           # environment variable used for CI/CD tests in this repo
           command: npx cypress-plugin-last-failed run --env shouldPass=true
           working-directory: ${{ github.workspace }}
-  custom-test-results:
+  burn-test-results:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout 📦
+        uses: actions/checkout@v4
+      - name: Cypress run - store failed tests in custom directory 👟
+        uses: cypress-io/github-action@v6
+        with:
+          # using cy-grep plugin burn test feature
+          command: npx cypress run --env burn=10
+          working-directory: ${{ github.workspace }}
+        continue-on-error: true
+      - name: Output the file contents 📝
+        if: always()
+        run: |
+          cat ./test-results/last-run.json
+      - name: Run failed tests from default directory 🧪
+        if: always()
+        uses: cypress-io/github-action@v6
+        with:
+          # environment variable used for CI/CD tests in this repo
+          command: npx cypress-plugin-last-failed run --env shouldPass=true
+          working-directory: ${{ github.workspace }}
+  custom-dir-test-results:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout 📦

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Checkout 📦
         uses: actions/checkout@v4
-      - name: Cypress run - store failed tests in custom directory 👟
+      - name: Cypress run - run burn=10 🔥
         uses: cypress-io/github-action@v6
         with:
           # using cy-grep plugin burn test feature

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "trailingComma": "es5",
+  "semi": true,
+  "singleQuote": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-plugin-last-failed",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "bin": {
         "cypress-plugin-last-failed": "runFailed.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Cypress plugin to rerun last failed tests in cypress run and open mode",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",


### PR DESCRIPTION
Re: https://github.com/dennisbergevin/cypress-plugin-last-failed/issues/15

Adds `cy-grep` burn test logic to the `after:run` methods involved in collecting failed tests from Cypress run, removing `: burning X of X` from the test title that is added from the `cy-grep` plugin.

Additionally, this effort adds new Github action test workflow surrounding using `--env burn=` feature.
