### PR TITLE
fix: Adding appropriate exit code to node script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,16 +21,12 @@ jobs:
           cat ./test-results/last-run.json
       - name: Run failed tests from default directory 🧪
         if: always()
-        run: |
-          set +e
-          npx cypress-plugin-last-failed run --env shouldPass=true
-          exitcode="$?"
-          echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
-      - name: Output the runFailed node script exit code 📝
-        if: always()
-        run: |
-          echo ${{ steps.run-failed.outputs.exitcode }}
-  fail-exit-code-check:
+        uses: cypress-io/github-action@v6
+        with:
+          # environment variable used for CI/CD tests in this repo
+          command: npx cypress-plugin-last-failed run --env shouldPass=true
+          working-directory: ${{ github.workspace }}
+  exit-code-check:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout 📦
@@ -73,15 +69,11 @@ jobs:
           cat ./test-results/last-run.json
       - name: Run failed tests from default directory 🧪
         if: always()
-        run: |
-          set +e
-          npx cypress-plugin-last-failed run --env shouldPass=true
-          exitcode="$?"
-          echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
-      - name: Output the runFailed node script exit code 📝
-        if: always()
-        run: |
-          echo ${{ steps.run-failed.outputs.exitcode }}
+        uses: cypress-io/github-action@v6
+        with:
+          # environment variable used for CI/CD tests in this repo
+          command: npx cypress-plugin-last-failed run --env shouldPass=true
+          working-directory: ${{ github.workspace }}
   custom-dir-test-results:
     runs-on: ubuntu-22.04
     steps:
@@ -99,12 +91,7 @@ jobs:
           cat ./cypress/config/test-results/last-run.json
       - name: Run failed tests from custom directory 🧪
         if: always()
-        run: |
-          set +e
-          npm run custom-dir-last-failed
-          exitcode="$?"
-          echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
-      - name: Output the runFailed node script exit code 📝
-        if: always()
-        run: |
-          echo ${{ steps.run-failed.outputs.exitcode }}
+        uses: cypress-io/github-action@v6
+        with:
+          command: npm run custom-dir-last-failed
+          working-directory: ${{ github.workspace }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,31 @@ jobs:
           # environment variable used for CI/CD tests in this repo
           command: npx cypress-plugin-last-failed run --env shouldPass=true
           working-directory: ${{ github.workspace }}
+  exit-code-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout 📦
+        uses: actions/checkout@v4
+      - name: Cypress run 👟
+        uses: cypress-io/github-action@v6
+        continue-on-error: true
+      - name: Output the file contents 📝
+        if: always()
+        run: |
+          cat ./test-results/last-run.json
+      - name: Run failed tests from default directory 🧪
+        id: run-failed
+        if: always()
+        continue-on-error: true
+        run: |
+          set +e
+          npx cypress-plugin-last-failed run
+          exitcode="$?"
+          echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
+      - name: Output the runFailed node script exit code 📝
+        if: always()
+        run: |
+          echo ${{ steps.run-failed.outputs.exitcode }}
   burn-test-results:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,12 +21,16 @@ jobs:
           cat ./test-results/last-run.json
       - name: Run failed tests from default directory 🧪
         if: always()
-        uses: cypress-io/github-action@v6
-        with:
-          # environment variable used for CI/CD tests in this repo
-          command: npx cypress-plugin-last-failed run --env shouldPass=true
-          working-directory: ${{ github.workspace }}
-  exit-code-check:
+        run: |
+          set +e
+          npx cypress-plugin-last-failed run --env shouldPass=true
+          exitcode="$?"
+          echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
+      - name: Output the runFailed node script exit code 📝
+        if: always()
+        run: |
+          echo ${{ steps.run-failed.outputs.exitcode }}
+  fail-exit-code-check:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout 📦
@@ -69,11 +73,15 @@ jobs:
           cat ./test-results/last-run.json
       - name: Run failed tests from default directory 🧪
         if: always()
-        uses: cypress-io/github-action@v6
-        with:
-          # environment variable used for CI/CD tests in this repo
-          command: npx cypress-plugin-last-failed run --env shouldPass=true
-          working-directory: ${{ github.workspace }}
+        run: |
+          set +e
+          npx cypress-plugin-last-failed run --env shouldPass=true
+          exitcode="$?"
+          echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
+      - name: Output the runFailed node script exit code 📝
+        if: always()
+        run: |
+          echo ${{ steps.run-failed.outputs.exitcode }}
   custom-dir-test-results:
     runs-on: ubuntu-22.04
     steps:
@@ -91,7 +99,12 @@ jobs:
           cat ./cypress/config/test-results/last-run.json
       - name: Run failed tests from custom directory 🧪
         if: always()
-        uses: cypress-io/github-action@v6
-        with:
-          command: npm run custom-dir-last-failed
-          working-directory: ${{ github.workspace }}
+        run: |
+          set +e
+          npm run custom-dir-last-failed
+          exitcode="$?"
+          echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
+      - name: Output the runFailed node script exit code 📝
+        if: always()
+        run: |
+          echo ${{ steps.run-failed.outputs.exitcode }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-plugin-last-failed",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "MIT",
       "bin": {
         "cypress-plugin-last-failed": "runFailed.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Cypress plugin to rerun last failed tests in cypress run and open mode",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/runFailed.js
+++ b/runFailed.js
@@ -51,7 +51,15 @@ Try running tests again with cypress run`;
       process.env.CYPRESS_grepFilterSpecs = true;
       process.env.CYPRESS_grepOmitFiltered = true;
 
-      await cypress.run(runOptions);
+      await cypress
+        .run(runOptions)
+        .then((results) => {
+          process.exit(results.totalFailed);
+        })
+        .catch((err) => {
+          console.error(err);
+          process.exit(1);
+        });
     } else {
       console.log(noFailedTestsMessage);
     }


### PR DESCRIPTION
Relates to: https://github.com/dennisbergevin/cypress-plugin-last-failed/issues/19

This effort adds handling for the appropriate exit code when using the plugin's custom node script via the Cypress module api.

Previously, there was no handling inside the custom script for failures, where running `npx cypress run` will display an exit code `0` for passing tests, or the number of failed tests in the run as exit code (i.e. 3 failed tests, will show exit code `3`).

