### PR TITLE
fix: Comma in the cypress test is not being picked up in the last failed run

### DIFF
--- a/cypress/e2e/tests.cy.js
+++ b/cypress/e2e/tests.cy.js
@@ -19,7 +19,7 @@ describe('Should run expected tests', () => {
     }
   });
 
-  it('will be included in failed tests', () => {
+  it('will, be included in failed tests', () => {
     if (Cypress.env('shouldPass')) {
       expect(10).to.eq(10);
     } else {
@@ -38,4 +38,12 @@ describe('Should run expected tests', () => {
   it('skipped', { requiredTags: '@skip' }, () => {
     expect(10).to.eq(10);
   });
+});
+
+it('non-suite test, 1', () => {
+  if (Cypress.env('shouldPass')) {
+    expect(true).to.eq(true);
+  } else {
+    expect(true).to.eq(false);
+  }
 });

--- a/cypress/e2e/tests.cy.js
+++ b/cypress/e2e/tests.cy.js
@@ -1,4 +1,4 @@
-describe('Should run expected tests', () => {
+describe('Should, run expected tests', () => {
   it('should run', () => {
     if (Cypress.env('shouldPass')) {
       expect(true).to.eq(true);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-plugin-last-failed",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "license": "MIT",
       "bin": {
         "cypress-plugin-last-failed": "runFailed.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Cypress plugin to rerun last failed tests in cypress run and open mode",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/runFailed.js
+++ b/runFailed.js
@@ -36,10 +36,7 @@ Try running tests again with cypress run`;
     );
 
     // Format string for use in grep functionality
-    const stringedTests = Array.from(resultSet)
-      .join('; ')
-      .toString()
-      .slice(0, -1);
+    const stringedTests = Array.from(resultSet).join('; ').toString();
 
     if (stringedTests.length > 0) {
       // Allow for additional cli arguments to be passed to the run command

--- a/runFailed.js
+++ b/runFailed.js
@@ -31,13 +31,14 @@ Try running tests again with cypress run`;
     // Combine parent suite and test together
     const resultSet = new Set(
       Object.values(parentAndTest).flatMap(
-        (parent) => parent.parent + ',' + parent.test + ';'
+        (parent) => parent.parent + ' ' + parent.test
       )
     );
+
     // Format string for use in grep functionality
     const stringedTests = Array.from(resultSet)
+      .join('; ')
       .toString()
-      .replaceAll(',', ' ')
       .slice(0, -1);
 
     if (stringedTests.length > 0) {

--- a/runFailed.js
+++ b/runFailed.js
@@ -29,9 +29,12 @@ Try running tests again with cypress run`;
       test,
     }));
     // Combine parent suite and test together
+    // If parent title is empty do not add space before test title
     const resultSet = new Set(
       Object.values(parentAndTest).flatMap(
-        (parent) => parent.parent + ' ' + parent.test
+        (parent) =>
+          (parent.parent !== '' ? parent.parent + ' ' : parent.parent) +
+          parent.test
       )
     );
 


### PR DESCRIPTION
Relates to: https://github.com/dennisbergevin/cypress-plugin-last-failed/issues/21

Commas included suite or test titles were being replaced with space when the `runFailed` node script read the `last-run.json` file.

This effort fixes that logic within `runFailed` node script to join the parent suite and test title while respecting commas in the parent/test title.

```bash
cy-grep: tests with "non-suite test, 1; Should, run expected tests should run; Should, run expected tests needs to run; Should, run expected tests will, be included in failed tests" in their names
cy-grep: will omit filtered tests
cy-grep: filtering specs using " non-suite test, 1; Should, run expected tests should run; Should, run expected tests needs to run; Should, run expected tests will, be included in failed tests" in the title
```