### PR TITLE
fix: Update parent separator logic to account for nested suite

### DIFF
--- a/cypress/e2e/tests.cy.js
+++ b/cypress/e2e/tests.cy.js
@@ -11,12 +11,23 @@ describe('Should, run expected tests', () => {
     expect(true).to.eq(true);
   });
 
-  it('needs to run', () => {
-    if (Cypress.env('shouldPass')) {
-      expect(1).to.eq(1);
-    } else {
-      expect(1).to.eq(2);
-    }
+  describe('Inner suite, 1', () => {
+    it('needs to run', () => {
+      if (Cypress.env('shouldPass')) {
+        expect(1).to.eq(1);
+      } else {
+        expect(1).to.eq(2);
+      }
+    });
+    describe('Inner suite, 2', () => {
+      it('needs to run', () => {
+        if (Cypress.env('shouldPass')) {
+          expect(1).to.eq(1);
+        } else {
+          expect(1).to.eq(2);
+        }
+      });
+    });
   });
 
   it('will, be included in failed tests', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-plugin-last-failed",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "license": "MIT",
       "bin": {
         "cypress-plugin-last-failed": "runFailed.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Cypress plugin to rerun last failed tests in cypress run and open mode",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/runFailed.js
+++ b/runFailed.js
@@ -28,13 +28,15 @@ Try running tests again with cypress run`;
       parent,
       test,
     }));
+
     // Combine parent suite and test together
     // If parent title is empty do not add space before test title
     const resultSet = new Set(
       Object.values(parentAndTest).flatMap(
         (parent) =>
-          (parent.parent !== '' ? parent.parent + ' ' : parent.parent) +
-          parent.test
+          (parent.parent !== ''
+            ? parent.parent.join(' ') + ' '
+            : parent.parent) + parent.test
       )
     );
 

--- a/src/index.js
+++ b/src/index.js
@@ -70,8 +70,12 @@ const generateReports = (tests, spec, config) => {
   if (config.env.burn) {
     const seen = new Set();
     const filteredReports = reports.filter((el) => {
-      const duplicate = seen.has(el.test);
-      seen.add(el.test);
+      const duplicate = seen.has(
+        (el.parent !== '' ? el.parent.join(' ') + ' ' : el.parent) + el.test
+      );
+      seen.add(
+        (el.parent !== '' ? el.parent.join(' ') + ' ' : el.parent) + el.test
+      );
       return !duplicate;
     });
     return filteredReports;


### PR DESCRIPTION
Where a nested suite is present, this effort adds the necessary empty space separation as required by `cy-grep` for all parent suite titles obtained originally as an array of titles from the `last-run.json`, as well as when `--env burn=X` is used to correctly determine duplicates when writing to `last-run.json`.