### PR TITLE
Troubleshooting section in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ jobs:
 
 For more information on Typescript support involved with `@bahmutov/cy-grep` package, refer to it's [README](https://github.com/bahmutov/cy-grep?tab=readme-ov-file#typescript-support).
 
+## Troubleshooting
+1. If you are having problems to generate the test-results folder with the last-run.json file make sure you are adding the collectFailingTests(on, config) call to the end of the plugin setup, after all other plugins have been initialized. This ensures the plugin's after:run handler is registered last and executes.
+
+
 ## Contributions
 
 Feel free to open a pull request or drop any feature request or bug in the [issues](https://github.com/dennisbergevin/cypress-plugin-last-failed/issues).


### PR DESCRIPTION
I was having the same issue again related to #13, and after some debugging, I realized the issue was the plugin registration order. When multiple plugins register handlers for the same event (like after:run), only the last registered handler executes. The cypress-plugin-last-failed plugin was being initialized before other plugins (like `cypress-qase-reporter`), so its `after:run` handler was being overridden. 

I think would be nice to add this information to a Troubleshooting section in the Readme in case other people have the same problem they can have some clue about it