### PR TITLE
[DO NOT MERGE] testing 2.1.0 showcase full test name behavior

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Run failed tests from default directory 🧪
         if: always()
         uses: cypress-io/github-action@v6
+        env:
+          DEBUG: cy-grep
         with:
           # environment variable used for CI/CD tests in this repo
           command: npx cypress-plugin-last-failed run --env shouldPass=true
@@ -45,6 +47,8 @@ jobs:
       - name: Run failed tests from default directory 🧪
         id: run-failed
         if: always()
+        env:
+          DEBUG: cy-grep
         continue-on-error: true
         run: |
           set +e
@@ -76,6 +80,8 @@ jobs:
       - name: Run failed tests from default directory 🧪
         if: always()
         uses: cypress-io/github-action@v6
+        env:
+          DEBUG: cy-grep
         with:
           # environment variable used for CI/CD tests in this repo
           command: npx cypress-plugin-last-failed run --env shouldPass=true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Cypress run 👟
         uses: cypress-io/github-action@v6
+        env:
+          DEBUG: cy-grep
         continue-on-error: true
       - name: Output the file contents 📝
         if: always()
@@ -33,6 +35,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Cypress run 👟
         uses: cypress-io/github-action@v6
+        env:
+          DEBUG: cy-grep
         continue-on-error: true
       - name: Output the file contents 📝
         if: always()
@@ -58,6 +62,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Cypress run - run burn=10 🔥
         uses: cypress-io/github-action@v6
+        env:
+          DEBUG: cy-grep
         with:
           # using cy-grep plugin burn test feature
           command: npx cypress run --env burn=10
@@ -81,6 +87,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Cypress run - store failed tests in custom directory 👟
         uses: cypress-io/github-action@v6
+        env:
+          DEBUG: cy-grep
         with:
           command: npm run custom-dir-run
           working-directory: ${{ github.workspace }}
@@ -92,6 +100,8 @@ jobs:
       - name: Run failed tests from custom directory 🧪
         if: always()
         uses: cypress-io/github-action@v6
+        env:
+          DEBUG: cy-grep
         with:
           command: npm run custom-dir-last-failed
           working-directory: ${{ github.workspace }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@bahmutov/cy-grep": "^2.1.0",
-        "cypress": "^15.11.0"
+        "cypress": "^15.12.0"
       }
     },
     "node_modules/@actions/core": {
@@ -1910,9 +1910,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.11.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.11.0.tgz",
-      "integrity": "sha512-NXDE6/fqZuzh1Zr53nyhCCa4lcANNTYWQNP9fJO+tzD3qVTDaTUni5xXMuigYjMujQ7CRiT9RkJJONmPQSsDFw==",
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.12.0.tgz",
+      "integrity": "sha512-B2BRcudLfA4NZZP5QpA45J70bu1heCH59V1yKRLHAtiC49r7RV03X5ifUh7Nfbk8QNg93RAsc6oAmodm/+j0pA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "devDependencies": {
     "@bahmutov/cy-grep": "^2.1.0",
-    "cypress": "^15.11.0"
+    "cypress": "^15.12.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Showcasing the `@bahmutov/cy-grep` v2.1.0 behavior using `CYPRESS_grep` where full test names (parent suite and test name) properly grep only the tests specified in the `CYPRESS_grep`.