### PR TITLE
chore: bump cypress v15.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-plugin-last-failed",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "bin": {
         "cypress-plugin-last-failed": "runFailed.js"
       },
       "devDependencies": {
-        "@bahmutov/cy-grep": "^3.0.3",
-        "cypress": "^15.13.0"
+        "@bahmutov/cy-grep": "^3.0.4",
+        "cypress": "^15.13.1"
       }
     },
     "node_modules/@actions/core": {
@@ -323,9 +323,9 @@
       }
     },
     "node_modules/@bahmutov/cy-grep": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bahmutov/cy-grep/-/cy-grep-3.0.3.tgz",
-      "integrity": "sha512-6eLJHw4JrvkuM+kG42Is33cHCuu+aYyg9eVynKvOWIXxzDExy0lkjqJ2D1RuPNlGoURxQfEIWU2rRisogxLafw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@bahmutov/cy-grep/-/cy-grep-3.0.4.tgz",
+      "integrity": "sha512-ubkx5lCdyIglwrqe9Lg423ACXVbRu8SLOt+oLWeD+ZFoNrzeXa/Bkp9cbc7KuduzTBTPLisy2AxyDoC8eWmw6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1887,9 +1887,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.13.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.13.0.tgz",
-      "integrity": "sha512-hJ9sY++TUC/HlUzHVJpIrDyqKMjlhx5PTXl/A7eA91JNEtUWkJAqefQR5mo9AtLra/9+m+JJaMg2U5Qd0a74Fw==",
+      "version": "15.13.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.13.1.tgz",
+      "integrity": "sha512-jLkgo75zlwo7PhXp0XJot+zIfFSDzN1SvTml6Xf3ETM1XHRWnH3Q4LAR3orCo/BsnxPnhjG3m5HYSvn9DAtwBg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3826,9 +3826,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Cypress plugin to rerun last failed tests in cypress run and open mode",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
@@ -18,8 +18,8 @@
     "cypress-plugin"
   ],
   "devDependencies": {
-    "@bahmutov/cy-grep": "^3.0.3",
-    "cypress": "^15.13.0"
+    "@bahmutov/cy-grep": "^3.0.4",
+    "cypress": "^15.13.1"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
- Addresses https://github.com/dennisbergevin/cypress-plugin-last-failed/pull/43
- Bumps cypress to v15.13.1 and cy-grep to v3.0.4