### PR TITLE
chore: update cypress 15.21.0 and refactor for new iframe on runner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "3.1.2",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-plugin-last-failed",
-      "version": "3.1.2",
+      "version": "4.0.0",
       "license": "MIT",
       "bin": {
         "cypress-plugin-last-failed": "runFailed.js"
       },
       "devDependencies": {
         "@bahmutov/cy-grep": "^3.0.4",
-        "cypress": "^15.18.1"
+        "cypress": "^15.21.0"
       }
     },
     "node_modules/@actions/core": {
@@ -1217,9 +1217,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/arch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
-      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-3.0.0.tgz",
+      "integrity": "sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==",
       "dev": true,
       "funding": [
         {
@@ -1623,6 +1623,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/chrome-remote-interface": {
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.33.3.tgz",
+      "integrity": "sha512-zNnn0prUL86Teru6UCAZ1yU1XeXljHl3gj7OrfPcarEfU62OUU4IujDPdTDW3dAWwRqN3ZMG/Chhkh2gPL/wiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "2.11.x",
+        "ws": "^7.2.0"
+      },
+      "bin": {
+        "chrome-remote-interface": "bin/client.js"
+      }
+    },
+    "node_modules/chrome-remote-interface/node_modules/commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -1830,9 +1851,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.18.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.18.1.tgz",
-      "integrity": "sha512-JtkTVtUE2lvLYgZCaug+Uai0H9IqsJirlBO49c87QwG0bJUGvAUVBz1EJve0b0oaYP244Ew9M0BkrHpcqkYxmw==",
+      "version": "15.21.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.21.0.tgz",
+      "integrity": "sha512-6uPy5GUjao97t/QDIwlPyJz4JUqPpFIPq5lNazN95LSA3ynJoYC1sHZ3W+aj4f+K1OFGbMfno0+OX2Gx0OmlPA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1843,12 +1864,13 @@
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "@types/tmp": "^0.2.3",
-        "arch": "^2.2.0",
+        "arch": "^3.0.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
         "buffer": "^5.7.1",
         "cachedir": "^2.4.0",
         "chalk": "^4.1.0",
+        "chrome-remote-interface": "0.33.3",
         "ci-info": "^4.1.0",
         "cli-table3": "0.6.1",
         "commander": "^6.2.1",
@@ -1874,7 +1896,6 @@
         "systeminformation": "^5.31.1",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
-        "tslib": "1.14.1",
         "untildify": "^4.0.0",
         "yauzl": "^3.3.1"
       },
@@ -3959,9 +3980,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -5349,13 +5370,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/tsx": {
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.0.tgz",
@@ -5431,9 +5445,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5656,6 +5670,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-plugin-last-failed",
-  "version": "3.1.2",
+  "version": "4.0.0",
   "description": "Cypress plugin to rerun last failed tests in cypress run and open mode",
   "main": "./src/index.js",
   "scripts": {
@@ -18,7 +18,7 @@
   ],
   "devDependencies": {
     "@bahmutov/cy-grep": "^3.0.4",
-    "cypress": "^15.18.1"
+    "cypress": "^15.21.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/src/toggle.js
+++ b/src/toggle.js
@@ -10,9 +10,9 @@ const grepFailed = () => {
   // @ts-ignore
   const failedTestTitles = [];
 
-  const failedTests = window.top?.document.querySelectorAll(
-    '.test.runnable.runnable-failed'
-  );
+  const failedTests = window.top?.document
+    .querySelector('iframe')
+    ?.contentDocument?.querySelectorAll('.test.runnable.runnable-failed');
 
   [...failedTests].forEach((test) => {
     failedTestTitles.push(test.innerText.split('\n')[0]);
@@ -23,8 +23,22 @@ const grepFailed = () => {
   } else {
     console.log('running only the failed tests');
     const grepTitles = failedTestTitles.join('; ');
+    const stopBtn = window.top?.document
+      .querySelector('iframe')
+      ?.contentDocument?.querySelector('.statsAndControls .stop');
+    // TODO: The cy-grep package has not been updated to handle the new Cypress runner UI iframe
+    // Remove this restartBtn handling once that package has been updated
+    const restartBtn = window.top?.document
+      .querySelector('iframe')
+      ?.contentDocument?.querySelector('.statsAndControls .restart');
+
     // @ts-ignore
     Cypress.grep(grepTitles);
+    if (stopBtn) {
+      stopBtn.click();
+    } else {
+      restartBtn.click();
+    }
   }
 };
 
@@ -33,8 +47,12 @@ const grepFailed = () => {
  */
 
 const failedTestToggle = () => {
-  const hasStyles = top?.document.querySelector('#runFailedStyle');
-  const hasToggleButton = top?.document.querySelector('#runFailedToggle');
+  const hasStyles = top?.document
+    .querySelector('iframe')
+    ?.contentDocument?.querySelector('#runFailedStyle');
+  const hasToggleButton = top?.document
+    .querySelector('iframe')
+    ?.contentDocument?.querySelector('#runFailedToggle');
   const defaultStyles = `
         .reporter header {
           overflow: visible;
@@ -111,9 +129,13 @@ const failedTestToggle = () => {
     let reporterEl;
     const reporterStyleEl = document.createElement('style');
     if (Cypress.version >= '15.0.0') {
-      reporterEl = window.top?.document.querySelector('.runnable-header');
+      reporterEl = window.top?.document
+        .querySelector('iframe')
+        ?.contentDocument?.querySelector('.runnable-header');
     } else {
-      reporterEl = window.top?.document.querySelector('#unified-reporter');
+      reporterEl = window.top?.document
+        .querySelector('iframe')
+        ?.contentDocument?.querySelector('#unified-reporter');
     }
     reporterStyleEl.setAttribute('id', 'runFailedStyle');
     reporterStyleEl.innerHTML = defaultStyles;
@@ -122,13 +144,9 @@ const failedTestToggle = () => {
 
   if (!hasToggleButton) {
     let header;
-    if (Cypress.version >= '15.0.0') {
-      // TODO: Cypress v15 GUI provides option for Cypress Studio which pushes the grep toggle button around the UI
-      // For simplicity, moving the toggle button to the spec container above the stop button
-      header = window.top?.document.querySelector('.runnable-header');
-    } else {
-      header = window.top?.document.querySelector('#unified-reporter header');
-    }
+    header = window.top?.document
+      .querySelector('iframe')
+      ?.contentDocument?.querySelector('.runnable-header');
     const headerToggleDiv = document.createElement('div');
     const headerToggleSpan = document.createElement('span');
     const headerToggleTooltip = document.createElement('span');
@@ -158,19 +176,31 @@ const failedTestToggle = () => {
     headerToggleButton?.appendChild(headerToggleLabel);
   }
 
-  const runFailedElement = top.document.querySelector('#runFailedToggle');
-  const runFailedLabelElement = top.document.querySelector(
-    '[for=runFailedToggle]'
-  );
-  const runFailedTooltipElement =
-    top.document.querySelector('#runFailedTooltip');
+  const runFailedElement = top.document
+    .querySelector('iframe')
+    ?.contentDocument?.querySelector('#runFailedToggle');
+  const runFailedLabelElement = top.document
+    .querySelector('iframe')
+    ?.contentDocument?.querySelector('[for=runFailedToggle]');
+  const runFailedTooltipElement = top.document
+    .querySelector('iframe')
+    ?.contentDocument?.querySelector('#runFailedTooltip');
 
   runFailedElement?.addEventListener('change', (e) => {
-    const stopBtn = window.top.document.querySelector('.reporter .stop');
+    const stopBtn = window.top.document
+      .querySelector('iframe')
+      ?.contentDocument?.querySelector('.reporter .stop');
+    // TODO: The cy-grep package has not been updated to handle the new Cypress runner UI iframe
+    // Remove this restartBtn handling once that package has been updated
+    const restartBtn = window.top?.document
+      .querySelector('iframe')
+      ?.contentDocument?.querySelector('.statsAndControls .restart');
 
     if (e.target.checked) {
       if (stopBtn) {
         stopBtn.click();
+      } else {
+        restartBtn.click();
       }
       // when checked, grep only failed tests in spec
       grepFailed();
@@ -183,6 +213,11 @@ const failedTestToggle = () => {
       }
       // when unchecked, ungrep and show all tests in spec
       Cypress.grep();
+      // TODO: The cy-grep package has not been updated to handle the new Cypress runner UI iframe
+      // Remove this restartBtn handling once that package has been updated
+      if (restartBtn) {
+        restartBtn.click();
+      }
       runFailedLabelElement.innerHTML = turnOffRunFailedIcon;
       runFailedTooltipElement.innerHTML = turnOffRunFailedDescription;
     }
@@ -197,8 +232,9 @@ const failedTestToggle = () => {
       const sidebarRunsLinkPage = window.top?.document.querySelector(
         '[data-cy="sidebar-link-runs-page"]'
       );
-      const runFailedToggleElement =
-        window.top?.document.querySelector('#runFailedToggle');
+      const runFailedToggleElement = window.top?.document
+        .querySelector('iframe')
+        ?.contentDocument?.querySelector('#runFailedToggle');
 
       if (
         window.top?.document.URL !=


### PR DESCRIPTION
Cypress recently introduced an iframe over the current open mode reporter where this plugin adds a toggle for filtering failed tests (https://github.com/cypress-io/cypress/pull/34242)

This new breaking version for the plugin updates the Cypress version and refactors the plugin's selectors used to setup the UI elements properly under this new imposed iframe.

**Note:** The [@bahmutov/cy-grep](https://github.com/bahmutov/cy-grep) plugin will require an update to handle the restart click function that has not updated to locate the restart button under new iframe. For now, this plugin will handle the functionality of clicking stop or restart button in the Cypress runner, but you may see console log errors referring back to cy-grep for this reason.